### PR TITLE
Persist validator during ExportBlock if it does not exist

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -75,5 +75,5 @@ func (w worker) process(height int64) error {
 		return err
 	}
 
-	return w.db.ExportBlock(block, txs)
+	return w.db.ExportBlock(block, txs, vals)
 }


### PR DESCRIPTION
Check if the proposer exists during `ExportBlock`. If it does not, persist it prior to the block.

closes: #1 